### PR TITLE
Fix IgniteGUI canvas panel name

### DIFF
--- a/Assets/IgniteModule/GUI/IgniteGUI.cs
+++ b/Assets/IgniteModule/GUI/IgniteGUI.cs
@@ -50,7 +50,7 @@ namespace IgniteModule
                 raycaster.blockingObjects = GraphicRaycaster.BlockingObjects.None;
 
                 // WindowRootRectTransform
-                var panelGameObject = new GameObject("IgntieGUICanvasPanel");
+                var panelGameObject = new GameObject("IgniteGUICanvasPanel");
                 panelTransform = panelGameObject.AddComponent<RectTransform>();
                 panelTransform.SetParent(canvasGameObject.transform);
                 panelTransform.SetAnchorPreset(AnchorPresets.StretchAll, true, true);


### PR DESCRIPTION
## Summary
- correct the "IgniteGUI" panel object name when creating the GUI canvas

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68404eca4bf88332be6a873e0720860c